### PR TITLE
SMOODEV-713: bump pnpm/action-setup@v2 to @v4

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: 22
       
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: 10
           


### PR DESCRIPTION
Part of cross-org GitHub Actions audit (SMOODEV-713). Bumps deprecated pnpm/action-setup@v2 to @v4 in pr-checks.yml.

## Test plan
- [ ] PR Checks workflow green on this PR

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>