### PR TITLE
SMOODEV-713: drop version: 10 input from pnpm/action-setup@v4

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,9 +18,8 @@ jobs:
           node-version: 22
       
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
-          
+
+
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
Hotfix for PR #70. pnpm/action-setup@v4 errors with 'Multiple versions of pnpm specified' when both 'version: 10' is set in the workflow and 'packageManager' is set in package.json. @v2 silently tolerated the duplicate; @v4 hard-fails.

Removing the workflow input — packageManager in package.json (currently pnpm@10.6.1) is the single source of truth.

## Test plan
- [ ] PR Checks workflow runs green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>