### PR TITLE
SMOODEV-732: Add ignoreDeprecations '6.0' to base.json

### DIFF
--- a/.changeset/smoodev-732-ignore-deprecations.md
+++ b/.changeset/smoodev-732-ignore-deprecations.md
@@ -1,0 +1,5 @@
+---
+'@smooai/config-typescript': patch
+---
+
+Add `ignoreDeprecations: '6.0'` to `base.json` so consumer packages with `baseUrl` don't fail typecheck on newer TypeScript versions. TS 6.x escalates `baseUrl` from a warning to a deprecation error.

--- a/base.json
+++ b/base.json
@@ -17,7 +17,8 @@
         "skipLibCheck": true,
         "strict": true,
         "noEmit": true,
-        "strictNullChecks": true
+        "strictNullChecks": true,
+        "ignoreDeprecations": "6.0"
     },
     "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- Adds `ignoreDeprecations: '6.0'` to `base.json` so consumer packages with `baseUrl` don't fail typecheck on TS 6.x
- TS 6.x escalates `baseUrl` from a warning to a deprecation error; this silences it for all consumers extending the shared base
- Unblocks SMOODEV-730 Node 24 env var rollout in `@smooai/utils` (PR #134) — once this releases, bump utils' config-typescript dep and PR #134 will go green

## Why this fix
Several SmooAI packages set `baseUrl` for path mapping (`@smooai/utils`, etc.). Rather than fix it consumer-by-consumer, fix at the shared base. Reversible by removing the single line once we migrate off `baseUrl` entirely (a tsc-7.0 imperative anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)