### PR TITLE
SMOODEV-732: Use ignoreDeprecations '5.0' (valid in TS 5.x)

### DIFF
--- a/.changeset/smoodev-732-deprecations-50.md
+++ b/.changeset/smoodev-732-deprecations-50.md
@@ -1,0 +1,5 @@
+---
+'@smooai/config-typescript': patch
+---
+
+Use `ignoreDeprecations: '5.0'` instead of `'6.0'` in `base.json`. TS 5.x only accepts `'5.0'` as the value; `'6.0'` errors out under TS 5.x consumers (e.g. utils on TS 5.8).

--- a/base.json
+++ b/base.json
@@ -18,7 +18,7 @@
         "strict": true,
         "noEmit": true,
         "strictNullChecks": true,
-        "ignoreDeprecations": "6.0"
+        "ignoreDeprecations": "5.0"
     },
     "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
PR #73 shipped `ignoreDeprecations: '6.0'` which is invalid under TypeScript 5.x. Consumers on TS 5.8 (e.g. `@smooai/utils`) error with `TS5103: Invalid value for '--ignoreDeprecations'`.

`'5.0'` is accepted by both TS 5.x and 6.x — safe across the consumer matrix.

## Reference
TypeScript 5.0 release notes added `ignoreDeprecations: '5.0'` as the official opt-in. TS 6.0 added `'6.0'` as an additional value but did NOT make it backwards-compatible with 5.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)