### PR TITLE
chore: unify README under Smoo AI brand and voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,57 @@
-<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+<p align="center">
+  <a href="https://smoo.ai"><img src="https://smoo.ai/images/logo/logo.svg" alt="Smoo AI" width="220" /></a>
+</p>
 
-<a name="readme-top"></a>
+<h1 align="center">@smooai/config-typescript</h1>
 
-<br />
-<div align="center">
-  <a href="https://smoo.ai">
-    <img src="images/logo.png" alt="SmooAI Logo" />
-  </a>
-</div>
+<p align="center">
+  <strong>Shared TypeScript configs that keep type checking and compilation consistent across every Smoo AI project.</strong>
+</p>
 
-<!-- ABOUT THE PROJECT -->
+<p align="center">
+  <a href="https://www.npmjs.com/package/@smooai/config-typescript"><img src="https://img.shields.io/npm/v/@smooai/config-typescript?style=flat-square&color=00A6A6&label=npm" alt="npm"></a>
+  <img src="https://img.shields.io/badge/Smoo_AI-platform-00A6A6?style=flat-square" alt="Smoo AI">
+  <img src="https://img.shields.io/badge/license-MIT-F49F0A?style=flat-square" alt="license">
+  <img src="https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript">
+</p>
 
-## About SmooAI
+<p align="center">
+  <a href="#-features">Features</a> ·
+  <a href="#-install">Install</a> ·
+  <a href="#-usage">Usage</a> ·
+  <a href="#-part-of-smoo-ai">Platform</a>
+</p>
 
-SmooAI is an AI-powered platform for helping businesses multiply their customer, employee, and developer experience.
+---
 
-Learn more on [smoo.ai](https://smoo.ai)
+> A collection of internal TypeScript configurations used across Smoo AI projects. Extend one of these `tsconfig` presets and your project inherits the same strict, modern, monorepo-friendly compiler settings we use everywhere. Derived from `@turbo/config-typescript`.
 
-## SmooAI Packages
+## ✨ Features
 
-Check out other SmooAI packages at [npmjs.com/org/smooai](https://www.npmjs.com/org/smooai)
+- Standard TypeScript configurations tuned for Smoo AI projects
+- Strict type checking enabled by default
+- Modern JavaScript feature support
+- Consistent settings across every repository
+- Optimized for monorepo setups
+- Presets available for:
+    - Node.js projects
+    - React applications
+    - Next.js applications
+    - Library packages
 
-## About @smooai/config-typescript
-
-Collection of internal TypeScript configurations used across SmooAI projects. This package provides standardized TypeScript configurations to ensure consistent type checking and compilation settings across all SmooAI repositories.
-
-Derived from `@turbo/config-typescript`.
-
-![NPM Version](https://img.shields.io/npm/v/%40smooai%2Fconfig-typescript?style=for-the-badge)
-![NPM Downloads](https://img.shields.io/npm/dw/%40smooai%2Fconfig-typescript?style=for-the-badge)
-![NPM Last Update](https://img.shields.io/npm/last-update/%40smooai%2Fconfig-typescript?style=for-the-badge)
-
-![GitHub License](https://img.shields.io/github/license/SmooAI/config-typescript?style=for-the-badge)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/SmooAI/config-typescript/release.yml?style=for-the-badge)
-![GitHub Repo stars](https://img.shields.io/github/stars/SmooAI/config-typescript?style=for-the-badge)
-
-### Installation
+## 📦 Install
 
 ```sh
 pnpm add -D @smooai/config-typescript
 ```
 
-Note: This package has a peer dependency on TypeScript. Make sure you have TypeScript installed in your project:
+This package has a peer dependency on TypeScript, so make sure it's installed too:
 
 ```sh
 pnpm add -D typescript
 ```
 
-### Usage
+## 🚀 Usage
 
 In your `tsconfig.json`:
 
@@ -57,54 +61,32 @@ In your `tsconfig.json`:
 }
 ```
 
-### Features
+Swap `base.json` for the preset that matches your target (Node, React, Next.js, or library).
 
-- Standard TypeScript configurations optimized for SmooAI projects
-- Strict type checking enabled
-- Modern JavaScript features support
-- Consistent configuration across projects
-- Optimized for monorepo setups
-- Configurations available for:
-    - Node.js projects
-    - React applications
-    - Next.js applications
-    - Library packages
+## 🧩 Part of Smoo AI
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+`@smooai/config-typescript` is part of the [Smoo AI](https://smoo.ai) platform — an AI-powered business platform with AI built into every product. Browse the rest of our open-source packages at [npmjs.com/org/smooai](https://www.npmjs.com/org/smooai), including:
 
-## Contributing
+- [@smooai/config](https://github.com/SmooAI/config) — type-safe config, secrets, and feature flags
+- [@smooai/logger](https://github.com/SmooAI/logger) — contextual logging for AWS and the browser
+- [@smooai/fetch](https://github.com/SmooAI/fetch) — resilient, type-safe HTTP client
 
-Contributions are welcome! This project uses [changesets](https://github.com/changesets/changesets) to manage versions and releases.
+## 🤝 Contributing
 
-### Development Workflow
+Contributions are welcome. This project uses [changesets](https://github.com/changesets/changesets) to manage versions and releases.
 
-1. Fork the repository
-2. Create your branch (`git checkout -b amazing-feature`)
-3. Make your changes
-4. Add a changeset to document your changes:
-
-    ```sh
-    pnpm changeset
-    ```
-
-    This will prompt you to:
-
-    - Choose the type of version bump (patch, minor, or major)
-    - Provide a description of the changes
-
-5. Commit your changes (`git commit -m 'Add some amazing feature'`)
-6. Push to the branch (`git push origin feature/amazing-feature`)
-7. Open a Pull Request
-
-### Pull Request Guidelines
-
-- Reference any related issues in your PR description
+1. Fork the repository.
+2. Create your branch (`git checkout -b amazing-feature`).
+3. Make your changes.
+4. Add a changeset to document them: `pnpm changeset` — it prompts for the version bump type (patch, minor, or major) and a description.
+5. Commit and push your branch.
+6. Open a pull request, referencing any related issues.
 
 The maintainers will review your PR and may request changes before merging.
 
-<!-- CONTACT -->
+## 📄 License
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+MIT © SmooAI. See [LICENSE](LICENSE).
 
 ## Contact
 
@@ -116,6 +98,10 @@ Brent Rager
 - [TikTok](https://www.tiktok.com/@brentragertech)
 - [Instagram](https://www.instagram.com/brentragertech/)
 
-Smoo Github: [https://github.com/SmooAI](https://github.com/SmooAI)
+Smoo GitHub: [github.com/SmooAI](https://github.com/SmooAI)
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+---
+
+<p align="center">
+  Built by <a href="https://smoo.ai"><strong>Smoo AI</strong></a> — AI built into every product.
+</p>


### PR DESCRIPTION
Rewrites the README with the standard Smoo AI branded header (logo, tagline, flat-square brand-color badges), the "Part of Smoo AI" section, and the footer line, in the shared brand voice. All real technical content (install, tsconfig usage, features, contributing, license) is preserved — restructured and rephrased only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)